### PR TITLE
Fixed pathString in order to retrieve path from Handlebars template

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ function generateCode(taskOptions) {
           debug('      Path: %s', pathString);
           const pathDef = model.paths[pathString];
           let groupKey = pathDef[options.groupBy];
-          pathDef.pathString = path;
+          pathDef.pathString = pathString;
 
           // Iterate through the allowed operations
           for (const operationString of _.intersection(Object.keys(pathDef), options.operations)) {


### PR DESCRIPTION
I assume pathDef.pathString should hold the "path" from the swagger doc, and not the path module which it is currently doing. At least this did it for me, so now I can use pathDef.pathString to get the path from my handlebars template